### PR TITLE
Update to 1.21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,7 @@ jobs:
     strategy:
       matrix:
         # Use these Java versions
-        java: [
-          17,    # Current Java LTS & minimum supported by Minecraft
-          21,    # Current Java LTS
-        ]
+        java: [21] # Minecraft 1.21 and newer requires Java 21
         # and run on both Linux and Windows
         os: [ubuntu-22.04, windows-2022]
     runs-on: ${{ matrix.os }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.4-SNAPSHOT'
+	id 'fabric-loom' version '1.7-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -21,7 +21,7 @@ repositories {
 
 
 loom {
-
+	accessWidenerPath = file("src/main/resources/powered-signs.accesswidener")
 }
 
 configurations {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21+build.9
 loader_version=0.16.5
 
 # Mod Properties
-mod_version=1.0.3.2
+mod_version=1.0.3.2+1.21
 maven_group=xyz.poweredsigns
 archives_base_name=poweredsigns
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.4
-loader_version=0.15.0
+minecraft_version=1.21
+yarn_mappings=1.21+build.9
+loader_version=0.16.5
 
 # Mod Properties
 mod_version=1.0.3.2
@@ -14,6 +14,6 @@ maven_group=xyz.poweredsigns
 archives_base_name=poweredsigns
 
 # Dependencies
-fabric_version=0.91.1+1.20.2
-cloth_config_version=12.0.111
-mod_menu_version=8.0.0
+fabric_version=0.102.0+1.21
+cloth_config_version=15.0.140
+mod_menu_version=11.0.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/xyz/poweredsigns/PoweredSigns.java
+++ b/src/main/java/xyz/poweredsigns/PoweredSigns.java
@@ -21,6 +21,8 @@ import xyz.poweredsigns.utils.SignUtils;
 import java.util.ArrayList;
 import java.util.List;
 
+import static net.minecraft.util.PathUtil.validatePath;
+
 public class PoweredSigns implements ModInitializer {
 	public static String MODID = "poweredsigns";
 	private static final Logger LOGGER = LoggerFactory.getLogger(MODID);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -15,6 +15,7 @@
 		"main": ["xyz.poweredsigns.PoweredSigns"],
 		"modmenu": ["xyz.poweredsigns.config.ModMenuIntegration"]
 	},
+	"accessWidener": "powered-signs.accesswidener",
 	"mixins": [
 		"poweredsigns.mixins.json"
 	],

--- a/src/main/resources/powered-signs.accesswidener
+++ b/src/main/resources/powered-signs.accesswidener
@@ -1,0 +1,5 @@
+accessWidener v2 named
+
+accessible method net/minecraft/util/Identifier <init> (Ljava/lang/String;Ljava/lang/String;)V
+
+accessible method net/minecraft/block/AbstractBlock isTransparent (Lnet/minecraft/block/BlockState;Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;)Z


### PR DESCRIPTION
Bumped versions in gradle.properties and build.gradle, and added an accesswidener file as `net.minecraft.util.Identifer` was changed to private and `net.minecraft.block.AbstractBlock isTransparent` was changed to protected.